### PR TITLE
chore: update ec2 lab for apr25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 terraform.tfstate
 terraform.tfstate*
 .terraform.lock.hcl
+terraform.tfvars

--- a/aws/ec2/alb.tf
+++ b/aws/ec2/alb.tf
@@ -4,7 +4,7 @@ resource "aws_lb" "alb" {
   internal           = false
   load_balancer_type = "application"
   security_groups    = [aws_security_group.http.id]
-  subnets            = var.subnets
+  subnets            = var.alb_subnets
 }
 
 resource "aws_lb_target_group" "http" {
@@ -22,7 +22,7 @@ resource "aws_lb_target_group_attachment" "ec2" {
 
 resource "aws_security_group" "http" {
   name        = "${local.name}-alb"
-  description = "Security group for whitelisting ports required for EcsSampleApp"
+  description = "Security group for whitelisting ports required for http"
   vpc_id      = var.vpc
 
   ingress {
@@ -43,7 +43,7 @@ resource "aws_security_group" "http" {
   }
 
   tags = {
-    Name = "default"
+    Name = "${local.name}-alb"
   }
 }
 
@@ -69,7 +69,7 @@ resource "aws_lb_listener_rule" "static" {
 
   condition {
     host_header {
-      values = ["ec2rule.${local.tags.lb_hostname}"]
+      values = [local.lb_hostname]
     }
   }
 }

--- a/aws/ec2/ec2.tf
+++ b/aws/ec2/ec2.tf
@@ -3,6 +3,7 @@ resource "aws_instance" "ec2" {
   instance_type          = "t3.micro"
   user_data              = file("userdata.tpl")
   vpc_security_group_ids = [aws_security_group.allow_http.id]
+  subnet_id              = var.ec2_subnet
   tags = {
     Name = "${local.name}-instance"
   }

--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -1,12 +1,23 @@
 locals {
-  name = var.name == "" ? random_pet.name.id : lower(var.name)
+  name        = var.name == "" ? random_pet.name.id : lower(var.name)
+  lb_hostname = "${local.name}.${data.aws_route53_zone.zone.name}"
   tags = {
-    lb_hostname = "${local.name}.${data.aws_route53_zone.zone.name}"
+    lb_hostname = local.lb_hostname
   }
 }
 
+data "harness_platform_current_account" "current" {}
+
 data "aws_route53_zone" "zone" {
   zone_id = var.hostedzone
+}
+
+resource "aws_route53_record" "alb" {
+  zone_id = data.aws_route53_zone.zone.zone_id
+  name    = local.lb_hostname
+  type    = "CNAME"
+  ttl     = "60"
+  records = [aws_lb.alb[0].dns_name]
 }
 
 resource "random_pet" "name" {

--- a/aws/ec2/output.tf
+++ b/aws/ec2/output.tf
@@ -7,7 +7,7 @@ output "ec2" {
 }
 
 output "rule" {
-  value = "https://app.harness.io/ng/account/<harness account id>/ce/autostopping-rules/rule/${harness_autostopping_rule_vm.rule.id}"
+  value = "https://app.harness.io/ng/account/${data.harness_platform_current_account.current.id}/ce/autostopping-rules/rule/${harness_autostopping_rule_vm.rule.id}"
 }
 
 output "url" {

--- a/aws/ec2/provider.tf
+++ b/aws/ec2/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     harness = {
       source  = "harness/harness"
-      version = "0.28.3"
+      version = "0.37.1"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/aws/ec2/rule.tf
+++ b/aws/ec2/rule.tf
@@ -1,12 +1,14 @@
 resource "harness_autostopping_aws_alb" "harness_alb" {
-  name                   = "${local.name}-lb"
-  cloud_connector_id     = var.harness_cloud_connector_id
-  host_name              = local.tags.lb_hostname
-  alb_arn                = var.alb_arn == "" ? aws_lb.alb[0].arn : var.alb_arn
-  region                 = var.region
-  vpc                    = var.vpc
-  security_groups        = [aws_security_group.http.id]
-  route53_hosted_zone_id = "/hostedzone/${var.hostedzone}"
+  name               = "${local.name}-lb"
+  cloud_connector_id = var.harness_cloud_connector_id
+  host_name          = local.lb_hostname
+  alb_arn            = var.alb_arn == "" ? aws_lb.alb[0].arn : var.alb_arn
+  region             = var.region
+  vpc                = var.vpc
+  security_groups    = [aws_security_group.http.id]
+  # setting hosted zone is not needed when route53 is already set up externally
+  # route53_hosted_zone_id            = "/hostedzone/${var.hostedzone}"
+  delete_cloud_resources_on_destroy = false
 }
 
 resource "harness_autostopping_rule_vm" "rule" {
@@ -35,5 +37,5 @@ resource "harness_autostopping_rule_vm" "rule" {
       status_code_to   = 299
     }
   }
-  custom_domains = ["ec2rule.${local.tags.lb_hostname}"]
+  custom_domains = [local.lb_hostname]
 }

--- a/aws/ec2/variable.tf
+++ b/aws/ec2/variable.tf
@@ -4,14 +4,16 @@ variable "name" {
   default     = ""
 }
 
-variable "subnets" {
-  type    = list(string)
-  default = ["subnet-682a8223", "subnet-e357d99a", "subnet-bef497e4"]
+variable "alb_subnets" {
+  type = list(string)
+}
+
+variable "ec2_subnet" {
+  type = string
 }
 
 variable "vpc" {
-  type    = string
-  default = "vpc-51edc228"
+  type = string
 }
 
 variable "region" {
@@ -20,13 +22,13 @@ variable "region" {
 }
 
 variable "ami" {
-  type    = string
-  default = "ami-0efcece6bed30fd98"
+  type        = string
+  default     = "ami-0efcece6bed30fd98"
+  description = "ubuntu ami (default for us-west-2)"
 }
 
 variable "hostedzone" {
-  type    = string
-  default = "Z2X614CI8JN37A"
+  type = string
 }
 
 variable "alb_arn" {
@@ -36,6 +38,5 @@ variable "alb_arn" {
 }
 
 variable "harness_cloud_connector_id" {
-  type    = string
-  default = "SE_AWS_CCM_Connector"
+  type = string
 }


### PR DESCRIPTION
brushing the lab off before sending to a customer

- update harness provider
- remove defaults that reference harness aws resources or harness connectors
- have users specify full domain for rule and route53 record
- seperate out ALB and EC2 subnets to allow them to be seperate (best practice to have ec2 in private subnet)
- do not set route53_hosted_zone_id on imported alb, let user control DNS

validated this works when
- applying all the tf at once
- applying all the AWS resources first, app works, then creating the alb/rule, still work after (once you fix the domain stuff in the UI)